### PR TITLE
Include sys/types.h from header.

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>

--- a/src/i2c.h
+++ b/src/i2c.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <sys/types.h>
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 


### PR DESCRIPTION
Fixes C++ compile, as ssize_t is used in i2c.h.