### PR TITLE
make reads non blocking and set device address once

### DIFF
--- a/include/i2c/i2c.h
+++ b/include/i2c/i2c.h
@@ -27,7 +27,7 @@ void i2c_close(int bus);
 int i2c_open(const char *bus_name);
 
 /* Initialize I2CDevice with default value */
-void i2c_init_device(I2CDevice *device);
+int i2c_init_device(I2CDevice *device);
 
 /* Get i2c device description */
 char *i2c_get_device_desc(const I2CDevice *device, char *buf, size_t size);


### PR DESCRIPTION
Slight modification of the library to make read operations non blocking when there is no data on the bus. Also move the i2c_select into init so that it is only called once for read/write operations. Feel free to modify!3