### PR TITLE
fix 8k read limit

### DIFF
--- a/include/i2c/i2c.h
+++ b/include/i2c/i2c.h
@@ -9,6 +9,8 @@ extern "C" {
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
+#define MAX_I2C_MSG_LEN         8192
+
 /* I2c device */
 typedef struct i2c_device {
     int bus;			        /* I2C Bus fd, return from i2c_open */


### PR DESCRIPTION
i2c_read() has a limitation that can only read 8192 bytes of chuck at a time. If user wants to read more, the function fails. Fix this by reading the chunks in a loop if data is larger than 8192 bytes.