### PR TITLE
fix(example): correct I2C write error check condition

### DIFF
--- a/example/i2c_tools.c
+++ b/example/i2c_tools.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
     print_i2c_data(buf, buf_size);
 
     ret = i2c_write_handle(&device, 0x0, buf, buf_size);
-    if (ret != -1 || (size_t)ret != buf_size)
+    if (ret == -1 || (size_t)ret != buf_size)
     {
 
         fprintf(stderr, "Write i2c error!\n");


### PR DESCRIPTION
The original write return value check used 'ret != -1 || ret != len', which was incorrect. This patch fixes the condition to 'ret == -1 || ret != len' to properly detect write failures.